### PR TITLE
Get rid of the warning related to HTTParty will no longer override `response#nil?`

### DIFF
--- a/lib/puppet/provider/graylog_api.rb
+++ b/lib/puppet/provider/graylog_api.rb
@@ -94,7 +94,7 @@ class Puppet::Provider::GraylogAPI < Puppet::Provider
           **tls_opts
         )
 
-        if result.body
+        if result.body && !result.body.empty?
           if result.body.include? '"type":"ApiError"'
             Puppet.send_log(:err, "Got error response #{result.body}")
             raise
@@ -106,7 +106,7 @@ class Puppet::Provider::GraylogAPI < Puppet::Provider
         Puppet.send_log(:err, "Got error response #{e.response}")
         raise e
       end
-      recursive_nil_to_undef(JSON.parse(result.body)) unless result.nil?
+      recursive_nil_to_undef(JSON.parse(result.body)) if result.body && !result.body.empty?
     end
 
     # Under Puppet Apply, undef in puppet-lang becomes :undef instead of nil


### PR DESCRIPTION
Get rid of the DEPRECATED warning in related to that functionality.

```
==> graylog: [DEPRECATION] HTTParty will no longer override `response#nil?`. This functionality will be removed in future versions. Please, add explicit check `response.body.nil? || response.body.empty?`. For more info refer to: https://github.com/jnunemaker/httparty/issues/568
==> graylog: /tmp/vagrant-puppet/environments/local/local-modules/graylog_api/lib/puppet/provider/graylog_api.rb:109:in `request'
==> graylog: [DEPRECATION] HTTParty will no longer override `response#nil?`. This functionality will be removed in future versions. Please, add explicit check `response.body.nil? || response.body.empty?`. For more info refer to: https://github.com/jnunemaker/httparty/issues/568
==> graylog: /tmp/vagrant-puppet/environments/local/local-modules/graylog_api/lib/puppet/provider/graylog_api.rb:109:in `request'
```
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Every calling the graylog_stream function for example, always displays the said deprecated warning.
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
